### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ English: http://core.telegram.org/mtproto/TL
 
 Russian: http://dev.stel.com/mtproto/TL
 
-####Telegram project
+#### Telegram project
 
 http://telegram.org/
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
